### PR TITLE
feature: #8 auto loading old massages when scrolling

### DIFF
--- a/SkillChat.Client.ViewModel/MainWindowViewModel.cs
+++ b/SkillChat.Client.ViewModel/MainWindowViewModel.cs
@@ -684,6 +684,8 @@ namespace SkillChat.Client.ViewModel
             HeaderMenuPopup
         }
 
+        public bool IsFirstRun { get; set; } = true;
+
         public void WindowStates(WindowState state)
         {
             switch (state)
@@ -692,6 +694,7 @@ namespace SkillChat.Client.ViewModel
                     SettingsViewModel.Close();
                     ProfileViewModel.ContextMenuClose();
                     ProfileViewModel.Close();
+                    IsFirstRun = true;
                     break;
                 case WindowState.OpenProfile:
                     SettingsViewModel.Close();

--- a/SkillChat.Client/Views/MainWindow.xaml
+++ b/SkillChat.Client/Views/MainWindow.xaml
@@ -167,15 +167,6 @@
                     <!--Profile - Шапка профиля -->
                     <Grid Grid.Column="2" Width="{Binding GridWidth}" ZIndex="1">
                         <StackPanel Orientation="Horizontal">
-                            <Button
-                                VerticalAlignment="Center"
-                                Background="Transparent"
-                                IsVisible="{Binding !SettingsActive}"
-                                BorderThickness="0"
-                                Command="{Binding LoadMessageHistoryCommand}"
-                                Content="Cтарые сообщения"
-                                FontSize="12"
-                                HorizontalAlignment="Left" />
                             <TextBlock Foreground="#4F4F4F"
                                        FontWeight="600"
                                        IsVisible="{Binding SettingsActive}"

--- a/SkillChat.Client/Views/MainWindow.xaml.cs
+++ b/SkillChat.Client/Views/MainWindow.xaml.cs
@@ -1,9 +1,9 @@
 ﻿using System;
 using Avalonia;
 using Avalonia.Controls;
-using Avalonia.Input;
 using Avalonia.Markup.Xaml;
 using SkillChat.Client.ViewModel;
+
 namespace SkillChat.Client.Views
 {
     public class MainWindow : Window, IHaveWidth, IHaveIsActive
@@ -11,13 +11,16 @@ namespace SkillChat.Client.Views
         public MainWindow()
         {
             InitializeComponent();
-			MessagesScroller = this.Get<ScrollViewer>("MessagesSV");
-            MessagesScroller.ScrollChanged += MessagesScroller_ScrollChanged; 
+            MessagesScroller = this.Get<ScrollViewer>("MessagesSV");
+            MessagesScroller.ScrollChanged += MessagesScroller_ScrollChanged;
             this.DataContextChanged += SetDataContextMethod;
 #if DEBUG
             this.AttachDevTools();
 #endif
         }
+
+        MainWindowViewModel ViewModel => DataContext as MainWindowViewModel;
+
         /// <summary>
         /// при изменение прокрутки проверят прокрученно ли до конца и сохраняет во ViewModel
         /// </summary>
@@ -25,43 +28,80 @@ namespace SkillChat.Client.Views
         /// <param name="e"></param>
         private void MessagesScroller_ScrollChanged(object sender, ScrollChangedEventArgs e)
         {
-            if (DataContext is MainWindowViewModel vm)
+            if (ViewModel != null)
             {
-              var verticaloffsetvalue = ScrollViewer.VerticalScrollBarValueProperty.Getter(MessagesScroller);
-              var verticaloffsetmax = ScrollViewer.VerticalScrollBarMaximumProperty.Getter(MessagesScroller);
-              vm.SettingsViewModel.AutoScroll = verticaloffsetmax.Equals(verticaloffsetvalue); 
+                var verticaloffsetvalue = ScrollViewer.VerticalScrollBarValueProperty.Getter(MessagesScroller);
+                var verticaloffsetmax = ScrollViewer.VerticalScrollBarMaximumProperty.Getter(MessagesScroller);
+                ViewModel.SettingsViewModel.AutoScroll = verticaloffsetmax.Equals(verticaloffsetvalue);
+
+                if (verticaloffsetmax != 0)
+                {
+                    if (ViewModel.IsFirstRun)
+                    {
+                        // можно задать нужную позицию
+                        MessagesScroller.ScrollToEnd();
+                        ViewModel.IsFirstRun = false;
+                    }
+                    else if (verticaloffsetvalue.Equals(0))
+                    {
+                        if (LastVerticaloffsetmax != verticaloffsetmax && isLoaded)
+                        {
+                            LastVerticaloffsetmax = verticaloffsetmax;
+                            MessagesScroller.LayoutUpdated += MessagesControlOnLayoutUpdated;
+                            isLoaded = false;
+                            ViewModel.LoadMessageHistoryCommand.Execute(null);
+                        }
+                    }
+                }
             }
         }
 
+        private double LastVerticaloffsetmax { get; set; }
+        private bool isLoaded = true;
+
         public void LayoutUpdated_window(object sender, EventArgs e)
         {
-            if (sender is MainWindow window && DataContext is MainWindowViewModel dataContext)
+            if (sender is MainWindow window && ViewModel != null)
             {
-                dataContext.windowIsFocused = window.IsFocused;
+                ViewModel.windowIsFocused = window.IsFocused;
             }
         }
 
         /// <summary>Контрол скролла для списка сообщений</summary>
         ScrollViewer MessagesScroller;
 
-        /// <summary>Устонавливаем текущий датаконтрекст</summary>
+        private void MessagesControlOnLayoutUpdated(object? sender, EventArgs e)
+        {
+            if (ViewModel != null)
+            {
+                MessagesScroller.LayoutUpdated -= MessagesControlOnLayoutUpdated;
+                var verticaloffsetmax = ScrollViewer.VerticalScrollBarMaximumProperty.Getter(MessagesScroller);
+                MessagesScroller.Offset =
+                    new Vector(MessagesScroller.Offset.X,
+                        verticaloffsetmax - LastVerticaloffsetmax);
+
+                isLoaded = true;
+            }
+        }
+
+        /// <summary>Устанавливаем текущий датаконтекст</summary>
         private void SetDataContextMethod(object sender, EventArgs e)
-		{
-			if (this.DataContext is MainWindowViewModel vm)
-			{
-                vm.MessageReceived += x => MessagesScroller.PropertyChanged += ScrollMethod;
-			}
-		}
+        {
+            if (ViewModel != null)
+            {
+                ViewModel.MessageReceived += x => MessagesScroller.PropertyChanged += ScrollMethod;
+            }
+        }
 
         /// <summary>При изменении размеров ScrollView скролит его вниз если разешено</summary>
         /// <param name="sender"></param>
         /// <param name="e"></param>
 		private void ScrollMethod(object sender, AvaloniaPropertyChangedEventArgs e)
-		{
+        {
 
-			if (e.Property.PropertyType.Name == "Size")
-                if(DataContext is MainWindowViewModel vm)
-                    if(vm.SettingsViewModel.AutoScroll)
+            if (e.Property.PropertyType.Name == "Size")
+                if (ViewModel != null)
+                    if (ViewModel.SettingsViewModel.AutoScroll)
                         MessagesScroller.ScrollToEnd();
             MessagesScroller.PropertyChanged -= ScrollMethod;
         }
@@ -70,7 +110,5 @@ namespace SkillChat.Client.Views
         {
             AvaloniaXamlLoader.Load(this);
         }
-
-    
     }
 }

--- a/SkillChat.Server.ServiceInterface/ChatService.cs
+++ b/SkillChat.Server.ServiceInterface/ChatService.cs
@@ -28,7 +28,8 @@ namespace SkillChat.Server.ServiceInterface
             {
                 messages = messages.Where(x => x.PostTime.UtcDateTime < request.BeforePostTime.Value.UtcDateTime);
             }
-            var pageSize = request.PageSize ?? 10;
+
+            var pageSize = request.PageSize ?? 50;
             
             var docs = 
                 await messages.Take(pageSize)


### PR DESCRIPTION
Данный код автоматически подгружает старые сообщения и немного прокручивает вниз. Что бы было совсем хорошо - было бы не плохо задавать положение скрола напрямую, находя разницу между его новым размером и старым (До подгрузки сообщений). Но нужный параметр в Avalonia.Controls.ScrollViewer имеет уровень доступа protected, что не позволяет этого сделать. Из последних изменений:
1) исправлена двойная загрузка сообщений при старте клиента. А так же положение скрола где то в центре истории сообщений, теперь он прокручивается на последнее сообщение.
2) при скролинге вверх при прогргузке всех сообщений, скрол больше не отскакивает ниже, будто подгрузил ещё сообщений.  