### PR TITLE
Пофиксил баг

### DIFF
--- a/SkillChat.Client.ViewModel/MainWindowViewModel.cs
+++ b/SkillChat.Client.ViewModel/MainWindowViewModel.cs
@@ -439,6 +439,7 @@ namespace SkillChat.Client.ViewModel
                 try
                 {
                     messageDictionary.Clear();
+                    EndEditCommand.Execute(null); 
                     Messages.Clear();
                     MessageText = null;
                     Tokens = null;

--- a/SkillChat.Server/Hubs/ChatHub.cs
+++ b/SkillChat.Server/Hubs/ChatHub.cs
@@ -87,7 +87,9 @@ namespace SkillChat.Server.Hubs
             {
                 var mes = await _ravenSession.LoadAsync<Message>(hubEditedMessage.Id);
 
-                if (mes.Text.Trim()!=hubEditedMessage.Message.Trim()||mes.IdQuotedMessage!= hubEditedMessage.IdQuotedMessage)
+                if (mes.UserId == Context.Items["uid"]?.ToString() && 
+                	(mes.Text.Trim()!=hubEditedMessage.Message.Trim() 
+                	|| mes.IdQuotedMessage!= hubEditedMessage.IdQuotedMessage))
                 {
                     mes.Text = hubEditedMessage.Message.Trim();
                     mes.LastEditTime = DateTimeOffset.Now;


### PR DESCRIPTION
Суть проблемы:
Если разлогиниться в режиме редактирования и залогиниться под другого, то при вводе первого сообщения будет редактироваться то сообщение, при редактировании которого был совершён акт разлогинивания.
Решение:
Добавил выполнение команды EndEditCommand в команду выхода из профиля SignOutCommand